### PR TITLE
آستانه هشدار قابل تنظیم با Repository Variable

### DIFF
--- a/.github/workflows/candle-alert.yml
+++ b/.github/workflows/candle-alert.yml
@@ -39,6 +39,10 @@ jobs:
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          # Optional override: set a repository Variable named
+          # ALTERNATION_THRESHOLD to change the alert sensitivity without
+          # touching code. Defaults to 6 when the variable is not set.
+          ALTERNATION_THRESHOLD: ${{ vars.ALTERNATION_THRESHOLD || '6' }}
         run: python check_candles.py
 
       # Save updated state for the next run (unique key always saves).


### PR DESCRIPTION
آستانه‌ی هشدار (`ALTERNATION_THRESHOLD`) را از یک **Repository Variable** در گیت‌هاب می‌خواند و در صورت نبودن متغیر، پیش‌فرض `6` می‌ماند.

با این تغییر می‌توان حساسیت هشدار را از رابط گیت‌هاب (مثلاً برای تست) بدون دست‌زدن به کد عوض کرد.

https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm

---
_Generated by [Claude Code](https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm)_