### PR TITLE
اجرای پیوسته‌ی ۲۴ ساعته به‌جای cron نامطمئن

### DIFF
--- a/.github/workflows/candle-alert.yml
+++ b/.github/workflows/candle-alert.yml
@@ -2,18 +2,23 @@ name: BTC Candle Alert
 
 on:
   schedule:
-    # Runs every 5 minutes. GitHub may delay runs under load.
-    - cron: "*/5 * * * *"
+    # Fires periodically so there is always a queued successor ready to take
+    # over when the long-running job ends. GitHub cron is unreliable, but we
+    # only need it to fire occasionally within each ~5.5h window.
+    - cron: "0 * * * *"
   workflow_dispatch: {}   # allows manual "Run workflow" from the GitHub UI
 
-# Prevent overlapping runs.
+# Keep exactly one monitor alive: a new run queues behind the current one and
+# starts the moment it finishes, giving near-continuous coverage.
 concurrency:
-  group: candle-alert
+  group: candle-monitor
   cancel-in-progress: false
 
 jobs:
-  check:
+  monitor:
     runs-on: ubuntu-latest
+    # Stay under the 6h hard limit; the process also self-exits earlier.
+    timeout-minutes: 350
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,29 +31,14 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      # Restore the last-alert state from the most recent previous run.
-      - name: Restore state
-        uses: actions/cache/restore@v4
-        with:
-          path: .state
-          key: candle-state-${{ github.run_id }}
-          restore-keys: |
-            candle-state-
-
-      - name: Check candles
+      - name: Run continuous monitor
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          # Optional override: set a repository Variable named
-          # ALTERNATION_THRESHOLD to change the alert sensitivity without
-          # touching code. Defaults to 6 when the variable is not set.
+          # Override alert sensitivity from a repository Variable (default 6).
           ALTERNATION_THRESHOLD: ${{ vars.ALTERNATION_THRESHOLD || '6' }}
-        run: python check_candles.py
-
-      # Save updated state for the next run (unique key always saves).
-      - name: Save state
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: .state
-          key: candle-state-${{ github.run_id }}
+          # Poll interval in seconds.
+          POLL_SECONDS: "30"
+          # Exit a bit before the 350-minute job timeout.
+          MAX_RUNTIME_SECONDS: "20400"
+        run: python monitor_loop.py

--- a/bot.py
+++ b/bot.py
@@ -192,8 +192,9 @@ class Monitor:
         log.info("ALERT fired (streak=%d).", streak)
         send_message(self.chat_id, text)
 
-    def run(self):
+    def run(self, max_runtime=None):
         # Prime history without alerting on past data.
+        started = time.time()
         try:
             initial = fetch_candles()
             if initial:
@@ -209,6 +210,9 @@ class Monitor:
 
         backoff = POLL_SECONDS
         while True:
+            if max_runtime is not None and time.time() - started >= max_runtime:
+                log.info("Max runtime (%ss) reached; exiting cleanly.", max_runtime)
+                return
             try:
                 candles = fetch_candles()
                 new = [c for c in candles if c["time"] > self.last_candle_time]

--- a/monitor_loop.py
+++ b/monitor_loop.py
@@ -1,0 +1,27 @@
+"""
+Long-running monitor entrypoint for GitHub Actions (public repo => free).
+
+Runs a single continuous process that polls Coinbase every POLL_SECONDS and
+sends Telegram alerts on candle-direction alternation. It exits cleanly after
+MAX_RUNTIME_SECONDS so the GitHub Actions job stays under the 6-hour limit;
+a queued successor run then takes over for near-continuous 24/7 coverage.
+"""
+
+import os
+
+from bot import Monitor, TELEGRAM_TOKEN, TELEGRAM_CHAT_ID, log
+
+# Default 5h40m, comfortably under the GitHub Actions 6h job limit.
+MAX_RUNTIME_SECONDS = int(os.environ.get("MAX_RUNTIME_SECONDS", "20400"))
+
+
+def main():
+    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+        raise SystemExit("Missing TELEGRAM_TOKEN or TELEGRAM_CHAT_ID.")
+    log.info("Long-running monitor starting (max_runtime=%ss).", MAX_RUNTIME_SECONDS)
+    monitor = Monitor(TELEGRAM_CHAT_ID)
+    monitor.run(max_runtime=MAX_RUNTIME_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## مشکل
زمان‌بند `cron` گیت‌هاب نامطمئن است؛ کل شب فقط ~۴ بار اجرا شد به‌جای هر ۵ دقیقه، پس بیشتر کندل‌ها بررسی نشدند.

## راه‌حل
به‌جای ۲۸۸ اجرای کوچک، یک **پروسه‌ی طولانیِ پیوسته**: هر ~۵.۵ ساعت یک اجرا که هر ۳۰ ثانیه کندل‌ها را چک می‌کند و سپس یک اجرای صف‌بندی‌شده جایش را می‌گیرد → پوشش ~۲۴ ساعته. چون این مخزن **عمومی** است، دقیقه‌های Actions نامحدود و رایگان است.

- `bot.py`: متد `Monitor.run()` حالا `max_runtime` می‌گیرد تا تمیز خارج شود.
- `monitor_loop.py`: نقطه‌ی ورود اجرای طولانی.
- workflow: تریگر ساعتی + `concurrency` برای صف‌بندی و پوشش پیوسته.

https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm

---
_Generated by [Claude Code](https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm)_