### PR TITLE
تنظیم آستانه روی ۶ (هشدار فقط روی تناوب واقعی)

### DIFF
--- a/.github/workflows/candle-alert.yml
+++ b/.github/workflows/candle-alert.yml
@@ -35,8 +35,9 @@ jobs:
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          # Override alert sensitivity from a repository Variable (default 6).
-          ALTERNATION_THRESHOLD: ${{ vars.ALTERNATION_THRESHOLD || '6' }}
+          # Alert threshold: number of consecutive alternating candles
+          # required to fire (6 candles = 5 color changes / تناوب).
+          ALTERNATION_THRESHOLD: "6"
           # Poll interval in seconds.
           POLL_SECONDS: "30"
           # Exit a bit before the 350-minute job timeout.


### PR DESCRIPTION
آستانه‌ی هشدار را مستقیم در workflow روی `6` قرار می‌دهد تا دیگر به متغیر تستِ `2` وابسته نباشد.

با `6`: ربات فقط وقتی آلارم می‌دهد که **۶ کندل پشت سر هم یک‌درمیان سبز/قرمز** شوند (۵ بار تناوب واقعی). دیگر با یک تغییر رنگ ساده (وقتی بیشتر کندل‌ها هم‌رنگ‌اند) آلارم نمی‌دهد.

https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm

---
_Generated by [Claude Code](https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm)_