### PR TITLE
آستانه روی ۵ کندل متناوب

### DIFF
--- a/.github/workflows/candle-alert.yml
+++ b/.github/workflows/candle-alert.yml
@@ -36,8 +36,8 @@ jobs:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           # Alert threshold: number of consecutive alternating candles
-          # required to fire (6 candles = 5 color changes / تناوب).
-          ALTERNATION_THRESHOLD: "6"
+          # required to fire (5 alternating candles = 4 color changes).
+          ALTERNATION_THRESHOLD: "5"
           # Poll interval in seconds.
           POLL_SECONDS: "30"
           # Exit a bit before the 350-minute job timeout.


### PR DESCRIPTION
آستانه‌ی هشدار را از ۶ به **۵ کندل متناوب پشت سر هم** کاهش می‌دهد (مطابق انتخاب کاربر: 🟢🔴🟢🔴🟢).

https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm

---
_Generated by [Claude Code](https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm)_