### PR TITLE
افزودن مانیتور موازی ۱۵ دقیقه‌ای بایننس (کنار ۵ دقیقه‌ای پلی‌مارکت)

### DIFF
--- a/.github/workflows/candle-alert.yml
+++ b/.github/workflows/candle-alert.yml
@@ -3,13 +3,13 @@ name: BTC Candle Alert
 on:
   schedule:
     # Fires periodically so there is always a queued successor ready to take
-    # over when the long-running job ends. GitHub cron is unreliable, but we
+    # over when the long-running jobs end. GitHub cron is unreliable, but we
     # only need it to fire occasionally within each ~5.5h window.
     - cron: "0 * * * *"
   workflow_dispatch: {}   # allows manual "Run workflow" from the GitHub UI
 
-# Keep exactly one monitor alive: a new run queues behind the current one and
-# starts the moment it finishes, giving near-continuous coverage.
+# Keep exactly one set of monitors alive: a new run queues behind the current
+# one and starts the moment it finishes, giving near-continuous coverage.
 concurrency:
   group: candle-monitor
   cancel-in-progress: false
@@ -19,6 +19,27 @@ jobs:
     runs-on: ubuntu-latest
     # Stay under the 6h hard limit; the process also self-exits earlier.
     timeout-minutes: 350
+    strategy:
+      fail-fast: false   # one monitor crashing must not stop the other
+      matrix:
+        include:
+          # 5-minute monitor — Polymarket BTC Up/Down series, threshold 5.
+          - name: "5m-polymarket"
+            source: "polymarket"
+            granularity: "300"
+            interval: "5m"
+            threshold: "5"
+            tf_label: "۵ دقیقه‌ای — Polymarket"
+            poly_prefix: "btc-updown-5m"
+          # 15-minute monitor — Binance BTCUSDT klines, threshold 4.
+          - name: "15m-binance"
+            source: "binance"
+            granularity: "900"
+            interval: "15m"
+            threshold: "4"
+            tf_label: "۱۵ دقیقه‌ای — Binance"
+            poly_prefix: "btc-updown-5m"
+    name: monitor-${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,12 +56,12 @@ jobs:
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          # Data source: Polymarket "BTC Up/Down 5m" recurring market series.
-          SOURCE: "polymarket"
-          POLY_SLUG_PREFIX: "btc-updown-5m"
-          # Alert threshold: number of consecutive alternating candles
-          # required to fire (5 alternating candles = 4 color changes).
-          ALTERNATION_THRESHOLD: "5"
+          SOURCE: ${{ matrix.source }}
+          GRANULARITY: ${{ matrix.granularity }}
+          INTERVAL: ${{ matrix.interval }}
+          ALTERNATION_THRESHOLD: ${{ matrix.threshold }}
+          TF_LABEL: ${{ matrix.tf_label }}
+          POLY_SLUG_PREFIX: ${{ matrix.poly_prefix }}
           # Poll interval in seconds.
           POLL_SECONDS: "30"
           # Exit a bit before the 350-minute job timeout.

--- a/bot.py
+++ b/bot.py
@@ -35,6 +35,9 @@ SOURCE = os.environ.get("SOURCE", "binance").strip().lower()
 PRODUCT = os.environ.get("PRODUCT", "BTCUSDT").strip()
 GRANULARITY = int(os.environ.get("GRANULARITY", "300"))  # 5 minutes
 INTERVAL = os.environ.get("INTERVAL", "5m").strip()  # Binance kline interval
+# Human label for the timeframe, shown in the alert so different monitors
+# (e.g. 5m vs 15m) are never confused.
+TF_LABEL = os.environ.get("TF_LABEL", "").strip()
 # Number of alternating candles required to fire the alert.
 ALTERNATION_THRESHOLD = int(os.environ.get("ALTERNATION_THRESHOLD", "5"))
 POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "20"))
@@ -316,17 +319,19 @@ class Monitor:
             {1: "🟢", -1: "🔴", 0: "⚪️"}[d] for d in self.directions[-streak:]
         )
         flips = streak - 1  # number of color changes (تناوب)
+        minutes = max(1, GRANULARITY // 60)
+        tf = TF_LABEL or f"{minutes} دقیقه‌ای"
         if SOURCE == "polymarket":
-            source_line = f"منبع: <b>Polymarket — BTC Up/Down 5m</b>\n"
+            source_line = f"منبع: <b>Polymarket — BTC Up/Down</b>\n"
             detail_line = f"آخرین نتیجه: {dir_label(self.directions[-1])}"
         else:
             source_line = f"نماد: <b>{PRODUCT}</b> (Binance)\n"
             detail_line = f"قیمت بسته‌شدن: <b>${candle['close']:,.2f}</b>"
         text = (
-            "🚨 <b>هشدار تناوب کندل بیت‌کوین</b> 🚨\n\n"
+            f"🚨 <b>هشدار تناوب — تایم‌فریم {tf}</b> 🚨\n\n"
             f"<b>{flips}</b> بار تناوب (تغییر رنگ) پشت سر هم رخ داده — "
-            f"یعنی <b>{streak}</b> کندل ۵ دقیقه‌ای متوالی جهت‌شان "
-            "یک‌درمیان عوض شده (سبز/قرمز).\n\n"
+            f"یعنی <b>{streak}</b> کندل <b>{minutes} دقیقه‌ای</b> متوالی "
+            "جهت‌شان یک‌درمیان عوض شده (سبز/قرمز).\n\n"
             f"الگو: {pattern}\n"
             f"{source_line}"
             f"کندل بسته‌شده: {when}\n"


### PR DESCRIPTION
دو مانیتور **به‌صورت موازی** اجرا می‌شوند (matrix در workflow):

- **۵ دقیقه‌ای** — منبع Polymarket (BTC Up/Down)، آستانه ۵ (بدون تغییر)
- **۱۵ دقیقه‌ای** — منبع Binance (BTCUSDT klines)، آستانه ۴

پیام هشدار حالا برچسب تایم‌فریم و تعداد دقیقه را نشان می‌دهد تا پیام‌های ۵ و ۱۵ هرگز قاطی نشوند (مثلاً «هشدار تناوب — تایم‌فریم ۱۵ دقیقه‌ای — Binance»).

https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm

---
_Generated by [Claude Code](https://claude.ai/code/session_016fe9esHoYT5oUPxT9i3wSm)_