### PR TITLE
Add installable PWA + GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pwa.yml
+++ b/.github/workflows/pwa.yml
@@ -1,0 +1,70 @@
+name: Build & Deploy PWA
+
+# Builds the installable web app (precomputes a year of alternation stats into
+# data.json, bundles the PWA shell) and publishes it to GitHub Pages.
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "منبع داده"
+        type: choice
+        default: "binance"
+        options: [binance, polymarket]
+      days:
+        description: "چند روز عقب"
+        type: string
+        default: "365"
+      tz:
+        description: "منطقه زمانی"
+        type: string
+        default: "Asia/Tehran"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - name: Restore data cache
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: btc-${{ inputs.source }}-cache-${{ github.run_id }}
+          restore-keys: btc-${{ inputs.source }}-cache-
+      - name: Build PWA
+        env:
+          ANALYSIS_SOURCE: ${{ inputs.source }}
+          ANALYSIS_DAYS: ${{ inputs.days }}
+          ANALYSIS_TZ: ${{ inputs.tz }}
+          POLY_SLEEP: "0.05"
+          PWA_OUT: site
+        run: python build_pwa.py
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/build_pwa.py
+++ b/build_pwa.py
@@ -1,0 +1,100 @@
+"""
+Build the static PWA: precompute the full alternation statistics for every
+window (both clock-hour and rolling 5-minute-step) and every weekday over the
+past year into site/data.json, then copy the PWA shell (pwa/*) next to it.
+
+The heavy work (alternation per window across a year) is done here once; the
+installed web app only sorts/filters the precomputed numbers, so it is instant
+and works offline.
+
+Run (after the data source is reachable, e.g. in CI):
+    PWA_OUT=site python build_pwa.py
+"""
+
+import os
+import json
+import shutil
+from datetime import datetime, timezone
+
+# Sensible defaults for the published app.
+os.environ.setdefault("ANALYSIS_SOURCE", "binance")
+os.environ.setdefault("ANALYSIS_DAYS", "365")
+os.environ.setdefault("ANALYSIS_TZ", "Asia/Tehran")
+
+import analyze_history as A  # noqa: E402  (env must be set first)
+
+OUT = os.environ.get("PWA_OUT", "site").strip()
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def pack(stats):
+    """Compact one summarize_hour() dict for JSON."""
+    return {
+        "n": stats["n"],
+        "avg": round(stats["avg"], 3),
+        "mn": stats["min"],
+        "mnc": stats["min_count"],
+        "mx": stats["max"],
+        "mxc": stats["max_count"],
+        "hist": [[v, c] for v, c in stats["hist"]],
+    }
+
+
+def main():
+    tz, tz_name = A.get_tz()
+    candles = A.get_candles()
+    if not candles:
+        raise SystemExit("No candles available — run where the source is reachable.")
+
+    clock = A.build_hour_samples(candles, tz)
+    rolling = A.build_rolling_samples(candles, tz)
+
+    clock_out, rolling_out = {}, {}
+    for wd in range(7):
+        c = []
+        for h in range(24):
+            vals = clock[wd][h]
+            if vals:
+                c.append({"start": h * 60, "label": A.hour_label(h), **pack(A.summarize_hour(vals))})
+        c.sort(key=lambda x: x["start"])
+        clock_out[str(wd)] = c
+
+        r = []
+        for (h, m), vals in rolling[wd].items():
+            r.append({"start": h * 60 + m, "label": A.window_label(h, m), **pack(A.summarize_hour(vals))})
+        r.sort(key=lambda x: x["start"])
+        rolling_out[str(wd)] = r
+
+    oldest = datetime.fromtimestamp(candles[0]["time"], tz=tz)
+    newest = datetime.fromtimestamp(candles[-1]["time"], tz=tz)
+    data = {
+        "meta": {
+            "source": A.ANALYSIS_SOURCE,
+            "candles": len(candles),
+            "tz": tz_name,
+            "oldest": oldest.strftime("%Y-%m-%d %H:%M"),
+            "newest": newest.strftime("%Y-%m-%d %H:%M"),
+            "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+            "win_minutes": A.WIN_MINUTES,
+        },
+        # Iranian display order, Mon=0..Sun=6 keys, with Persian names.
+        "order": A.WEEKDAY_DISPLAY_ORDER,
+        "names": {str(k): v for k, v in A.PERSIAN_WEEKDAY.items()},
+        "clock": clock_out,
+        "rolling": rolling_out,
+    }
+
+    os.makedirs(OUT, exist_ok=True)
+    # Copy the PWA shell (index.html, app.js, manifest, sw.js, icons).
+    shell = os.path.join(HERE, "pwa")
+    for name in os.listdir(shell):
+        shutil.copy(os.path.join(shell, name), os.path.join(OUT, name))
+    with open(os.path.join(OUT, "data.json"), "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, separators=(",", ":"))
+
+    print(f"PWA built into {OUT}/ — {len(candles):,} candles, "
+          f"{sum(len(v) for v in rolling_out.values())} rolling windows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const WIN_MINUTES = 60;
+const DAY_MINUTES = 24 * 60;
+let DATA = null;
+
+const $ = (id) => document.getElementById(id);
+
+function fmtTime(min) {
+  const h = Math.floor(min / 60), m = min % 60;
+  return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+}
+
+// Greedy non-overlapping pick: skip a window whose 60-min span overlaps an
+// already-chosen one (circular distance so 23:35 and 00:35 don't overlap).
+function pick(list, n, noOverlap) {
+  const chosen = [];
+  for (const item of list) {
+    if (noOverlap) {
+      let clash = false;
+      for (const c of chosen) {
+        let d = Math.abs(item.start - c.start);
+        d = Math.min(d, DAY_MINUTES - d);
+        if (d < WIN_MINUTES) { clash = true; break; }
+      }
+      if (clash) continue;
+    }
+    chosen.push(item);
+    if (chosen.length >= n) break;
+  }
+  return chosen;
+}
+
+function histBars(hist) {
+  const max = Math.max(...hist.map((p) => p[1]), 1);
+  const wrap = document.createElement('div');
+  wrap.className = 'hist';
+  for (const [v, c] of hist) {
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    bar.innerHTML =
+      `<span class="k">${v}</span>` +
+      `<span class="b" style="width:${Math.round((c / max) * 120) + 2}px"></span>` +
+      `<span class="c">${c}</span>`;
+    wrap.appendChild(bar);
+  }
+  return wrap;
+}
+
+function render() {
+  if (!DATA) return;
+  const mode = $('window').value;
+  const order = $('order').value;
+  const wdSel = $('weekday').value;
+  const topn = Math.max(1, parseInt($('topn').value || '2', 10));
+  const noOverlap = $('nooverlap').checked;
+  const showHist = $('hist').checked;
+  const highest = order === 'highest';
+
+  const days = wdSel === 'all' ? DATA.order : [parseInt(wdSel, 10)];
+  const out = $('out');
+  out.innerHTML = '';
+
+  for (const wd of days) {
+    let list = (DATA[mode][String(wd)] || []).slice();
+    if (!list.length) continue;
+    list.sort((a, b) => (highest ? b.avg - a.avg : a.avg - b.avg)
+      || (highest ? b.mx - a.mx : a.mx - b.mx) || a.start - b.start);
+    const chosen = pick(list, topn, noOverlap);
+
+    const card = document.createElement('div');
+    card.className = 'day';
+    card.innerHTML = `<h2>${DATA.names[String(wd)]}</h2>`;
+
+    chosen.forEach((w, i) => {
+      const div = document.createElement('div');
+      div.className = 'win';
+      const star = i === 0 ? ' <span class="star">★</span>' : '';
+      div.innerHTML =
+        `<span class="badge">${i + 1}</span>` +
+        `<div class="t">${w.label}${star}</div>` +
+        `<div class="row"><span>تکرار در سال</span><b>${w.n} بار</b></div>` +
+        `<div class="row"><span>میانگین تناوب</span><b>${w.avg.toFixed(2)}</b></div>` +
+        `<div class="row"><span>کم‌ترین</span><b>${w.mn} (${w.mnc} بار)</b></div>` +
+        `<div class="row"><span>بیشینه</span><b>${w.mx} (${w.mxc} بار)</b></div>`;
+      if (showHist) div.appendChild(histBars(w.hist));
+      card.appendChild(div);
+    });
+    out.appendChild(card);
+  }
+}
+
+function fillWeekdays() {
+  const sel = $('weekday');
+  for (const wd of DATA.order) {
+    const o = document.createElement('option');
+    o.value = String(wd);
+    o.textContent = DATA.names[String(wd)];
+    sel.appendChild(o);
+  }
+}
+
+async function init() {
+  try {
+    const res = await fetch('./data.json', { cache: 'no-cache' });
+    DATA = await res.json();
+  } catch (e) {
+    $('meta').textContent = 'خطا در بارگذاری داده.';
+    return;
+  }
+  const m = DATA.meta;
+  $('meta').innerHTML =
+    `منبع: ${m.source} • ${m.candles.toLocaleString('en')} کندل • ` +
+    `${m.oldest} تا ${m.newest} • ${m.tz}`;
+  fillWeekdays();
+  ['window', 'order', 'weekday', 'topn', 'nooverlap', 'hist'].forEach((id) =>
+    $(id).addEventListener('input', render));
+  render();
+}
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () =>
+    navigator.serviceWorker.register('./sw.js').catch(() => {}));
+}
+init();

--- a/pwa/icon.svg
+++ b/pwa/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#0b3d66"/>
+  <!-- alternating green/red candles -->
+  <g stroke-width="14" stroke-linecap="round">
+    <line x1="120" y1="120" x2="120" y2="392" stroke="#2ecc71"/>
+    <rect x="98" y="170" width="44" height="120" rx="8" fill="#2ecc71"/>
+    <line x1="216" y1="110" x2="216" y2="402" stroke="#e74c3c"/>
+    <rect x="194" y="220" width="44" height="120" rx="8" fill="#e74c3c"/>
+    <line x1="312" y1="120" x2="312" y2="392" stroke="#2ecc71"/>
+    <rect x="290" y="160" width="44" height="120" rx="8" fill="#2ecc71"/>
+    <line x1="408" y1="110" x2="408" y2="402" stroke="#e74c3c"/>
+    <rect x="386" y="230" width="44" height="120" rx="8" fill="#e74c3c"/>
+  </g>
+</svg>

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b3d66">
+  <title>تناوب بیت‌کوین</title>
+  <link rel="manifest" href="./manifest.webmanifest">
+  <link rel="apple-touch-icon" href="./icon.svg">
+  <link rel="icon" href="./icon.svg">
+  <style>
+    :root { --blue:#0b3d66; --line:#d6e0ea; --bg:#f4f7fb; }
+    * { box-sizing: border-box; font-family: system-ui, "Segoe UI", Tahoma, sans-serif; }
+    body { margin:0; background:var(--bg); color:#1a1a1a; }
+    header { background:var(--blue); color:#fff; padding:14px 16px;
+             position:sticky; top:0; z-index:5; }
+    header h1 { margin:0; font-size:17px; }
+    header .meta { font-size:11px; opacity:.85; margin-top:4px; line-height:1.6; }
+    .controls { padding:12px 14px; display:grid; grid-template-columns:1fr 1fr;
+                gap:10px; background:#fff; border-bottom:1px solid var(--line); }
+    .ctrl { display:flex; flex-direction:column; gap:4px; }
+    .ctrl label { font-size:12px; color:#555; }
+    select, input[type=number] { padding:9px; border:1px solid var(--line);
+                border-radius:8px; font-size:15px; background:#fff; }
+    .toggles { grid-column:1 / -1; display:flex; gap:18px; flex-wrap:wrap; }
+    .toggles label { font-size:14px; display:flex; align-items:center; gap:6px; }
+    main { padding:12px 14px 40px; }
+    .day { margin-bottom:18px; background:#fff; border:1px solid var(--line);
+           border-radius:12px; overflow:hidden; }
+    .day h2 { margin:0; background:#e8eef5; color:var(--blue); font-size:15px;
+              padding:9px 12px; }
+    .win { padding:10px 12px; border-top:1px solid #eef2f6; }
+    .win .t { font-weight:700; font-size:16px; color:var(--blue); }
+    .win .badge { float:left; background:#0b3d66; color:#fff; border-radius:20px;
+                  font-size:12px; padding:2px 9px; }
+    .row { display:flex; justify-content:space-between; font-size:13px;
+           color:#333; margin-top:6px; gap:8px; }
+    .row b { color:#0b3d66; }
+    .hist { margin-top:8px; }
+    .bar { display:flex; align-items:center; gap:6px; font-size:12px; margin:2px 0; }
+    .bar .k { width:14px; text-align:center; color:#666; }
+    .bar .b { height:12px; background:#3a7bd5; border-radius:3px; min-width:2px; }
+    .bar .c { color:#666; }
+    .hint { font-size:12px; color:#777; padding:0 14px 24px; line-height:1.8; }
+    .star { color:#b8860b; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>📊 تناوب کندل ۵ دقیقه‌ای بیت‌کوین</h1>
+    <div class="meta" id="meta">در حال بارگذاری…</div>
+  </header>
+
+  <div class="controls">
+    <div class="ctrl">
+      <label>نوع بازه</label>
+      <select id="window">
+        <option value="rolling">لغزان (هر ۵ دقیقه)</option>
+        <option value="clock">راس‌ساعت</option>
+      </select>
+    </div>
+    <div class="ctrl">
+      <label>مرتب‌سازی</label>
+      <select id="order">
+        <option value="lowest">کم‌ترین تناوب</option>
+        <option value="highest">بیشترین تناوب</option>
+      </select>
+    </div>
+    <div class="ctrl">
+      <label>روز</label>
+      <select id="weekday"><option value="all">همه‌ی روزها</option></select>
+    </div>
+    <div class="ctrl">
+      <label>تعداد بازه در هر روز</label>
+      <input type="number" id="topn" value="2" min="1" max="12">
+    </div>
+    <div class="toggles">
+      <label><input type="checkbox" id="nooverlap" checked> بدون هم‌پوشانی</label>
+      <label><input type="checkbox" id="hist" checked> نمایش نمودار توزیع</label>
+    </div>
+  </div>
+
+  <main id="out"></main>
+  <div class="hint">
+    «تناوب» = طول بلندترین رشته‌ی یک‌درمیون شدن رنگ (سبز/قرمز) داخل هر بازه‌ی ۶۰ دقیقه‌ای،
+    برحسب تعداد تغییر رنگ. مقدار ۰ یعنی بازه تک‌رنگ بوده. مرتب‌سازی بر اساس «میانگین» است.
+    این اپ آفلاین کار می‌کند — می‌توانید از منوی مرورگر آن را روی صفحه‌ی اصلی نصب کنید.
+  </div>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/pwa/manifest.webmanifest
+++ b/pwa/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "تناوب کندل بیت‌کوین",
+  "short_name": "تناوب BTC",
+  "description": "آمار تناوب کندل ۵ دقیقه‌ای بیت‌کوین برای روزها و ساعت‌های هفته",
+  "lang": "fa",
+  "dir": "rtl",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#f4f7fb",
+  "theme_color": "#0b3d66",
+  "icons": [
+    { "src": "./icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,0 +1,36 @@
+// Simple offline-first service worker for the BTC alternation PWA.
+const CACHE = 'btc-tanavob-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './app.js',
+  './data.json',
+  './manifest.webmanifest',
+  './icon.svg',
+];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(ASSETS)).then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+// Cache-first, falling back to network (and caching new responses).
+self.addEventListener('fetch', (e) => {
+  if (e.request.method !== 'GET') return;
+  e.respondWith(
+    caches.match(e.request).then((hit) =>
+      hit || fetch(e.request).then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(e.request, copy)).catch(() => {});
+        return res;
+      }).catch(() => hit)
+    )
+  );
+});


### PR DESCRIPTION
build_pwa.py precomputes a year of alternation stats (clock + rolling, all weekdays) into site/data.json and bundles the offline PWA shell (pwa/). The app sorts/filters client-side: window type, lowest/highest, weekday, top-N, non-overlap, and a distribution chart. pwa.yml publishes it to GitHub Pages.