### PR TITLE
Persist predictor on/off state across cloud restarts

### DIFF
--- a/.github/workflows/predict-bot.yml
+++ b/.github/workflows/predict-bot.yml
@@ -12,6 +12,10 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch: {}   # allows manual "Run workflow" from the GitHub UI
 
+# Lets the bot persist its on/off state to a dedicated branch via GITHUB_TOKEN.
+permissions:
+  contents: write
+
 # Keep exactly one predictor alive: a new run queues behind the current one and
 # starts the moment it finishes.
 concurrency:
@@ -39,10 +43,13 @@ jobs:
         env:
           # Dedicated token => a different Telegram bot/chat from the alert bot.
           PREDICT_TELEGRAM_TOKEN: ${{ secrets.PREDICT_TELEGRAM_TOKEN }}
-          # Optional: set this secret so it keeps sending after each restart
-          # without you having to message the bot again.
+          # Optional override; normally the chat id is captured on first /start
+          # and persisted automatically, so this can stay empty.
           PREDICT_TELEGRAM_CHAT_ID: ${{ secrets.PREDICT_TELEGRAM_CHAT_ID }}
-          # Start predicting automatically (cloud restarts every ~5.5h).
+          # Token used to persist on/off state to the predict-bot-state branch.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Default to ON for the very first run (before any persisted state);
+          # after the first /start, the persisted state takes over.
           PREDICT_AUTOSTART: "1"
           # Send the guess ~60s before each 5-minute candle opens.
           PREDICT_LEAD_SECONDS: "60"

--- a/predict_bot.py
+++ b/predict_bot.py
@@ -48,6 +48,7 @@ except Exception:
     pass
 
 from predictor import predict, explain
+import state_store
 
 # ---------------------------------------------------------------------------
 # Configuration (uses its OWN env vars so it never clashes with bot.py)
@@ -324,18 +325,21 @@ def command_listener(state: State):
                 if not state.chat_id:
                     state.chat_id = chat_id
                     log.info("Captured chat_id: %s", chat_id)
+                    state_store.save(state.active, chat_id)
 
                 if text.startswith("/start"):
                     state.chat_id = chat_id
                     with state.lock:
                         state.active = True
                         state.last_predicted_open = 0  # allow immediate fire
+                    state_store.save(True, chat_id)  # persist across restarts
                     send_message(chat_id, START_TEXT)
                     log.info("Activated by /start (chat_id=%s).", chat_id)
 
                 elif text.startswith("/stop"):
                     with state.lock:
                         state.active = False
+                    state_store.save(False, state.chat_id)  # persist OFF
                     send_message(
                         chat_id,
                         "⏹ متوقف شد. دیگر پیش‌بینی نمی‌فرستم.\n"
@@ -382,9 +386,22 @@ def main():
         )
 
     state = State(TELEGRAM_CHAT_ID)
-    if AUTOSTART:
+    # Restore the on/off state + chat id persisted by a previous run, so the
+    # bot keeps running across cloud restarts and a user's /stop sticks until
+    # they send /start again.
+    remote = state_store.load()
+    if remote is not None:
+        state.active = bool(remote.get("active", AUTOSTART))
+        if remote.get("chat_id"):
+            state.chat_id = str(remote["chat_id"])
+        log.info(
+            "Loaded persisted state: active=%s, chat_id=%s.",
+            state.active,
+            "set" if state.chat_id else "none",
+        )
+    elif AUTOSTART:
         state.active = True
-        log.info("AUTOSTART enabled — predicting without waiting for /start.")
+        log.info("No persisted state; AUTOSTART on — active from launch.")
 
     listener = threading.Thread(
         target=command_listener, args=(state,), daemon=True

--- a/state_store.py
+++ b/state_store.py
@@ -1,0 +1,133 @@
+"""
+Tiny persistent state store for the predictor bot, backed by a dedicated branch
+in the same GitHub repo (so it survives the ~5.5h GitHub Actions restarts).
+
+It saves a small JSON file ({"active": bool, "chat_id": "..."}) on a branch that
+no workflow watches, using the automatic GITHUB_TOKEN (needs `contents: write`).
+This lets /start and /stop — and the captured chat id — persist across runs, so
+the bot keeps running fully automatically and only the user's Telegram commands
+change its on/off state.
+
+When GITHUB_TOKEN / GITHUB_REPOSITORY are not present (e.g. running locally),
+everything degrades gracefully: load() returns None and save() is a no-op, so
+the bot just falls back to PREDICT_AUTOSTART + in-memory state.
+"""
+
+import os
+import json
+import base64
+import logging
+
+import requests
+
+log = logging.getLogger("btc-predict-bot")
+
+API = "https://api.github.com"
+TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+REPO = os.environ.get("GITHUB_REPOSITORY", "").strip()  # "owner/repo"
+BRANCH = os.environ.get("PREDICT_STATE_BRANCH", "predict-bot-state").strip()
+PATH = os.environ.get("PREDICT_STATE_PATH", "predict_state.json").strip()
+
+TIMEOUT = 15
+
+
+def enabled() -> bool:
+    return bool(TOKEN and REPO)
+
+
+def _headers():
+    return {
+        "Authorization": f"Bearer {TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "btc-predict-bot/1.0",
+    }
+
+
+def _ensure_branch() -> bool:
+    """Create the state branch (off the default branch) if it doesn't exist."""
+    try:
+        r = requests.get(
+            f"{API}/repos/{REPO}/git/ref/heads/{BRANCH}",
+            headers=_headers(),
+            timeout=TIMEOUT,
+        )
+        if r.status_code == 200:
+            return True
+        repo = requests.get(
+            f"{API}/repos/{REPO}", headers=_headers(), timeout=TIMEOUT
+        ).json()
+        base = repo.get("default_branch", "main")
+        br = requests.get(
+            f"{API}/repos/{REPO}/git/ref/heads/{base}",
+            headers=_headers(),
+            timeout=TIMEOUT,
+        )
+        if br.status_code != 200:
+            return False
+        sha = br.json()["object"]["sha"]
+        cr = requests.post(
+            f"{API}/repos/{REPO}/git/refs",
+            headers=_headers(),
+            timeout=TIMEOUT,
+            json={"ref": f"refs/heads/{BRANCH}", "sha": sha},
+        )
+        return cr.status_code in (200, 201)
+    except requests.RequestException as exc:
+        log.warning("state: ensure_branch failed: %s", exc)
+        return False
+
+
+def load():
+    """Return {"active": bool, "chat_id": str, "_sha": str} or None."""
+    if not enabled():
+        return None
+    try:
+        r = requests.get(
+            f"{API}/repos/{REPO}/contents/{PATH}",
+            headers=_headers(),
+            params={"ref": BRANCH},
+            timeout=TIMEOUT,
+        )
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        content = base64.b64decode(data["content"]).decode("utf-8")
+        state = json.loads(content)
+        state["_sha"] = data.get("sha")
+        return state
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        log.warning("state: load failed: %s", exc)
+        return None
+
+
+def save(active: bool, chat_id: str) -> bool:
+    """Persist the active flag + chat id. Returns True on success."""
+    if not enabled():
+        return False
+    if not _ensure_branch():
+        return False
+    try:
+        existing = load()
+        payload = {"active": bool(active), "chat_id": chat_id or ""}
+        body = {
+            "message": "chore: update predictor on/off state",
+            "content": base64.b64encode(
+                json.dumps(payload).encode("utf-8")
+            ).decode("ascii"),
+            "branch": BRANCH,
+        }
+        if existing and existing.get("_sha"):
+            body["sha"] = existing["_sha"]
+        r = requests.put(
+            f"{API}/repos/{REPO}/contents/{PATH}",
+            headers=_headers(),
+            json=body,
+            timeout=TIMEOUT,
+        )
+        ok = r.status_code in (200, 201)
+        if not ok:
+            log.warning("state: save failed (%s): %s", r.status_code, r.text[:200])
+        return ok
+    except requests.RequestException as exc:
+        log.warning("state: save failed: %s", exc)
+        return False


### PR DESCRIPTION
Makes the next-candle predictor bot run fully automatically and survive GitHub Actions' ~5.5h restarts, while still being controlled by Telegram `/start` and `/stop`.

## How
- `state_store.py` saves a tiny JSON (`{active, chat_id}`) to a dedicated `predict-bot-state` branch using the workflow's `GITHUB_TOKEN` (no extra secret, no external service). No workflow triggers on that branch, so it causes no extra runs.
- `predict_bot.py` loads this state on launch and writes it on `/start`, `/stop`, and first chat-id capture. So after a one-time `/start`, the bot keeps predicting across restarts; a `/stop` sticks until the user sends `/start` again.
- The workflow gets `permissions: contents: write` and passes `GITHUB_TOKEN`. Chat id is now captured automatically — the `PREDICT_TELEGRAM_CHAT_ID` secret is optional.
- Degrades gracefully with no token (local runs): falls back to `PREDICT_AUTOSTART` + in-memory state.

https://claude.ai/code/session_01FoKD8ouRPCm7y5ZjnnSQp9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoKD8ouRPCm7y5ZjnnSQp9)_