### PR TITLE
Replace min stat with probability of above-average alternation

### DIFF
--- a/analyze_history.py
+++ b/analyze_history.py
@@ -563,13 +563,17 @@ def summarize_hour(values):
     n = len(values)
     mn = min(values)
     mx = max(values)
+    avg = sum(values) / n
+    # Share of occurrences whose alternation is strictly above the average.
+    above = sum(1 for v in values if v > avg)
     return {
         "n": n,
-        "avg": sum(values) / n,
+        "avg": avg,
         "min": mn,
         "min_count": values.count(mn),
         "max": mx,
         "max_count": values.count(mx),
+        "above_pct": round(100 * above / n, 1),
         "hist": sorted(Counter(values).items()),  # [(value, count), ...]
     }
 
@@ -710,11 +714,10 @@ def main():
         for rank, (start_min, label, s) in enumerate(chosen, start=1):
             print(f"  {rank}) {label}  (به وقت {tz_name})")
             print(f"       • تعداد تکرار این {unit} در سال : {s['n']} بار")
-            print(
-                f"       • کم‌ترین تناوب متوالی        : {s['min']} "
-                f"(در {s['min_count']} بار از {s['n']})"
-            )
             print(f"       • میانگین تناوب در این {unit}   : {s['avg']:.2f}")
+            print(
+                f"       • احتمال تناوب بالای میانگین   : {s['above_pct']}%"
+            )
             print(
                 f"       • بیشینه تناوب در این {unit}     : {s['max']} "
                 f"(در {s['max_count']} بار از {s['n']} تکرار شده)"

--- a/build_pwa.py
+++ b/build_pwa.py
@@ -32,8 +32,7 @@ def pack(stats):
     return {
         "n": stats["n"],
         "avg": round(stats["avg"], 3),
-        "mn": stats["min"],
-        "mnc": stats["min_count"],
+        "ap": stats["above_pct"],  # % of occurrences above the average
         "mx": stats["max"],
         "mxc": stats["max_count"],
         "hist": [[v, c] for v, c in stats["hist"]],

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -81,7 +81,7 @@ function render() {
         `<div class="t">${w.label}${star}</div>` +
         `<div class="row"><span>تکرار در سال</span><b>${w.n} بار</b></div>` +
         `<div class="row"><span>میانگین تناوب</span><b>${w.avg.toFixed(2)}</b></div>` +
-        `<div class="row"><span>کم‌ترین</span><b>${w.mn} (${w.mnc} بار)</b></div>` +
+        `<div class="row"><span>احتمال تناوب بالای میانگین</span><b>${w.ap}%</b></div>` +
         `<div class="row"><span>بیشینه</span><b>${w.mx} (${w.mxc} بار)</b></div>`;
       if (showHist) div.appendChild(histBars(w.hist));
       card.appendChild(div);

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v1';
+const CACHE = 'btc-tanavob-v2';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
The minimum was almost always 1 and uninformative, so drop it. Add above_pct = share of occurrences whose alternation exceeds the window's average, surfaced in the CLI report, the JSON, and the PWA (SW cache bumped).