### PR TITLE
Add Coinbase source and 15m timeframe; selectable in the PWA

### DIFF
--- a/analyze_history.py
+++ b/analyze_history.py
@@ -125,13 +125,23 @@ def selected_weekdays():
 POLY_MAX_MISSING = int(os.environ.get("POLY_MAX_MISSING", "2016"))  # ~7 days
 POLY_SLEEP = float(os.environ.get("POLY_SLEEP", "0.1"))
 
-# Default cache file depends on the source so the two never collide.
-_default_cache = (
-    ".cache/poly_updown.csv"
-    if ANALYSIS_SOURCE == "polymarket"
-    else ".cache/klines.csv"
-)
+# Default cache file depends on the source/interval so they never collide.
+if ANALYSIS_SOURCE == "polymarket":
+    _default_cache = ".cache/poly_updown.csv"
+else:
+    _default_cache = f".cache/{ANALYSIS_SOURCE}_{INTERVAL}.csv"
 CACHE_FILE = os.environ.get("CACHE_FILE", _default_cache).strip()
+
+# Coinbase Exchange public candles host(s). No API key required.
+COINBASE_HOSTS = [
+    h.strip()
+    for h in os.environ.get(
+        "COINBASE_HOSTS",
+        "https://api.exchange.coinbase.com,https://api.pro.coinbase.com",
+    ).split(",")
+    if h.strip()
+]
+COINBASE_PRODUCT = os.environ.get("COINBASE_PRODUCT", "BTC-USD").strip()
 
 # Persian weekday names, ordered the Iranian way (week starts on Saturday).
 # Mapping is from Python's date.weekday(): Monday=0 ... Sunday=6.
@@ -232,6 +242,95 @@ def fetch_year(days):
 
     candles = [out[k] for k in sorted(out)]
     return candles
+
+
+# ---------------------------------------------------------------------------
+# Parametrized fetchers (used by the multi-exchange / multi-timeframe PWA)
+# ---------------------------------------------------------------------------
+def fetch_binance(interval, granularity, days, product="BTCUSDT"):
+    """Binance klines for any interval, oldest -> newest."""
+    now_ms = int(time.time() * 1000)
+    cur = now_ms - days * 86400 * 1000
+    step = granularity * 1000
+    out = {}
+    while cur < now_ms:
+        rows, last_err = None, None
+        for host in BINANCE_HOSTS:
+            try:
+                resp = requests.get(
+                    f"{host}/api/v3/klines",
+                    params={"symbol": product, "interval": interval,
+                            "startTime": cur, "endTime": now_ms, "limit": 1000},
+                    timeout=20, headers={"User-Agent": "btc-history-analysis/1.0"},
+                )
+                resp.raise_for_status()
+                rows = resp.json()
+                break
+            except requests.RequestException as exc:
+                last_err = exc
+        if rows is None:
+            raise last_err if last_err else RuntimeError("all Binance hosts failed")
+        if not rows:
+            break
+        for row in rows:
+            ot, ct = int(row[0]), int(row[6])
+            if ct / 1000.0 > time.time():
+                continue
+            out[ot] = {"time": ot // 1000, "open": float(row[1]),
+                       "high": float(row[2]), "low": float(row[3]),
+                       "close": float(row[4])}
+        nxt = int(rows[-1][0]) + step
+        if nxt <= cur:
+            break
+        cur = nxt
+        if len(rows) < 1000:
+            break
+        time.sleep(0.2)
+    return [out[k] for k in sorted(out)]
+
+
+def fetch_coinbase(granularity, days, product="BTC-USD"):
+    """
+    Coinbase Exchange candles, oldest -> newest. The public endpoint returns at
+    most 300 candles per request as [time, low, high, open, close, volume].
+    """
+    now = int(time.time())
+    seg_start = (now - days * 86400)
+    seg_start -= seg_start % granularity
+    span = 300 * granularity
+    out = {}
+    reqs = 0
+    while seg_start < now:
+        seg_end = min(seg_start + span, now)
+        s_iso = datetime.fromtimestamp(seg_start, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        e_iso = datetime.fromtimestamp(seg_end, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        rows, last_err = None, None
+        for host in COINBASE_HOSTS:
+            try:
+                resp = requests.get(
+                    f"{host}/products/{product}/candles",
+                    params={"granularity": granularity, "start": s_iso, "end": e_iso},
+                    timeout=20, headers={"User-Agent": "btc-history-analysis/1.0"},
+                )
+                resp.raise_for_status()
+                rows = resp.json()
+                break
+            except requests.RequestException as exc:
+                last_err = exc
+        if rows is None:
+            raise last_err if last_err else RuntimeError("all Coinbase hosts failed")
+        for row in rows:  # [time, low, high, open, close, volume]
+            t = int(row[0])
+            if t + granularity > now:
+                continue  # candle not fully closed yet
+            out[t] = {"time": t, "open": float(row[3]), "high": float(row[2]),
+                      "low": float(row[1]), "close": float(row[4])}
+        reqs += 1
+        if reqs % 25 == 0:
+            print(f"  ...coinbase {reqs} requests, {len(out)} candles so far")
+        seg_start = seg_end
+        time.sleep(0.2)
+    return [out[k] for k in sorted(out)]
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +579,20 @@ def get_candles():
             "5-minute window (slow); progress is cached and resumable."
         )
         return fetch_year_polymarket(ANALYSIS_DAYS)
+    if ANALYSIS_SOURCE == "coinbase":
+        cached = load_cache()
+        if cached:
+            newest = datetime.fromtimestamp(cached[-1]["time"], tz=timezone.utc)
+            age_h = (datetime.now(timezone.utc) - newest).total_seconds() / 3600
+            span_days = (newest - datetime.fromtimestamp(cached[0]["time"], tz=timezone.utc)).days
+            if age_h < 24 and span_days >= ANALYSIS_DAYS - 2:
+                print(f"Using cached Coinbase candles ({len(cached)} rows).")
+                return cached
+        print(f"Downloading ~{ANALYSIS_DAYS} days of {INTERVAL} Coinbase {COINBASE_PRODUCT}...")
+        candles = fetch_coinbase(GRANULARITY, ANALYSIS_DAYS, COINBASE_PRODUCT)
+        if candles:
+            save_cache(candles)
+        return candles
     return get_candles_binance()
 
 
@@ -532,7 +645,7 @@ def build_hour_samples(candles, tz):
     return samples
 
 
-def build_rolling_samples(candles, tz, win=12):
+def build_rolling_samples(candles, tz, win=None):
     """
     Returns: samples[weekday][(hour, minute)] = list of per-window flip counts.
 
@@ -545,7 +658,13 @@ def build_rolling_samples(candles, tz, win=12):
     n = len(candles)
     times = [c["time"] for c in candles]
     dirs = [candle_direction(c) for c in candles]
-    full_span = (win - 1) * GRANULARITY  # seconds between first & last open
+    # Infer the candle step (seconds) from the data so this works for any
+    # timeframe (5m, 15m, ...) regardless of the module-level GRANULARITY.
+    diffs = [times[i + 1] - times[i] for i in range(min(n - 1, 1000))]
+    step = min((d for d in diffs if d > 0), default=GRANULARITY)
+    if win is None:
+        win = max(2, round(3600 / step))  # a 60-minute window
+    full_span = (win - 1) * step  # seconds between first & last open
 
     samples = {wd: {} for wd in range(7)}
     for i in range(n - win + 1):

--- a/build_pwa.py
+++ b/build_pwa.py
@@ -1,13 +1,13 @@
 """
-Build the static PWA: precompute the full alternation statistics for every
-window (both clock-hour and rolling 5-minute-step) and every weekday over the
-past year into site/data.json, then copy the PWA shell (pwa/*) next to it.
+Build the static PWA data: precompute the full alternation statistics for every
+window (clock-hour and rolling) and every weekday over the past year, for each
+combination of exchange (Binance, Coinbase) and timeframe (5m, 15m), into
+site/data.json. Then copy the PWA shell (pwa/*) next to it.
 
-The heavy work (alternation per window across a year) is done here once; the
-installed web app only sorts/filters the precomputed numbers, so it is instant
-and works offline.
+The installed web app just sorts/filters these precomputed numbers, so it is
+instant and works offline, and lets the user switch exchange + timeframe.
 
-Run (after the data source is reachable, e.g. in CI):
+Run (where the exchanges are reachable, e.g. in CI):
     PWA_OUT=site python build_pwa.py
 """
 
@@ -16,37 +16,47 @@ import json
 import shutil
 from datetime import datetime, timezone
 
-# Sensible defaults for the published app.
-os.environ.setdefault("ANALYSIS_SOURCE", "binance")
-os.environ.setdefault("ANALYSIS_DAYS", "365")
 os.environ.setdefault("ANALYSIS_TZ", "Asia/Tehran")
-
 import analyze_history as A  # noqa: E402  (env must be set first)
 
 OUT = os.environ.get("PWA_OUT", "site").strip()
+DAYS = int(os.environ.get("ANALYSIS_DAYS", "365"))
 HERE = os.path.dirname(os.path.abspath(__file__))
+
+# (key, exchange-label, timeframe-label, source, interval, granularity, product)
+CONFIGS = [
+    ("binance_5m", "Binance", "۵ دقیقه", "binance", "5m", 300, "BTCUSDT"),
+    ("binance_15m", "Binance", "۱۵ دقیقه", "binance", "15m", 900, "BTCUSDT"),
+    ("coinbase_5m", "Coinbase", "۵ دقیقه", "coinbase", "5m", 300, "BTC-USD"),
+    ("coinbase_15m", "Coinbase", "۱۵ دقیقه", "coinbase", "15m", 900, "BTC-USD"),
+]
 
 
 def pack(stats):
-    """Compact one summarize_hour() dict for JSON."""
     return {
         "n": stats["n"],
         "avg": round(stats["avg"], 3),
-        "ap": stats["above_pct"],  # % of occurrences above the average
+        "ap": stats["above_pct"],
         "mx": stats["max"],
         "mxc": stats["max_count"],
         "hist": [[v, c] for v, c in stats["hist"]],
     }
 
 
-def main():
-    tz, tz_name = A.get_tz()
-    candles = A.get_candles()
-    if not candles:
-        raise SystemExit("No candles available — run where the source is reachable.")
+def fetch(source, interval, granularity, product):
+    if source == "coinbase":
+        return A.fetch_coinbase(granularity, DAYS, product)
+    return A.fetch_binance(interval, granularity, DAYS, product)
 
+
+def build_dataset(tz, source, interval, granularity, product, ex_label, tf_label):
+    candles = fetch(source, interval, granularity, product)
+    if not candles:
+        print(f"  ⚠️  no candles for {source} {interval}")
+        return None
+    win = max(2, round(3600 / granularity))  # 60-minute window
     clock = A.build_hour_samples(candles, tz)
-    rolling = A.build_rolling_samples(candles, tz)
+    rolling = A.build_rolling_samples(candles, tz, win=win)
 
     clock_out, rolling_out = {}, {}
     for wd in range(7):
@@ -66,33 +76,74 @@ def main():
 
     oldest = datetime.fromtimestamp(candles[0]["time"], tz=tz)
     newest = datetime.fromtimestamp(candles[-1]["time"], tz=tz)
-    data = {
+    return {
         "meta": {
-            "source": A.ANALYSIS_SOURCE,
-            "candles": len(candles),
-            "tz": tz_name,
+            "exchange": ex_label, "timeframe": tf_label, "source": source,
+            "interval": interval, "candles": len(candles),
             "oldest": oldest.strftime("%Y-%m-%d %H:%M"),
             "newest": newest.strftime("%Y-%m-%d %H:%M"),
-            "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
-            "win_minutes": A.WIN_MINUTES,
         },
-        # Iranian display order, Mon=0..Sun=6 keys, with Persian names.
-        "order": A.WEEKDAY_DISPLAY_ORDER,
-        "names": {str(k): v for k, v in A.PERSIAN_WEEKDAY.items()},
         "clock": clock_out,
         "rolling": rolling_out,
     }
 
+
+def lowest_rolling(ds, wd):
+    """Return (label, avg) of the calmest rolling window for a weekday."""
+    items = ds["rolling"][str(wd)]
+    if not items:
+        return ("—", float("nan"))
+    best = min(items, key=lambda x: x["avg"])
+    return (best["label"], best["avg"])
+
+
+def main():
+    tz, tz_name = A.get_tz()
+    datasets = {}
+    for key, ex_label, tf_label, source, interval, gran, product in CONFIGS:
+        print(f"== building {key} ({ex_label} {tf_label}) ==")
+        try:
+            ds = build_dataset(tz, source, interval, gran, product, ex_label, tf_label)
+        except Exception as exc:  # one exchange failing must not kill the rest
+            print(f"  ⚠️  {key} failed: {exc}")
+            ds = None
+        if ds:
+            datasets[key] = ds
+            print(f"  {key}: {ds['meta']['candles']:,} candles")
+
+    if not datasets:
+        raise SystemExit("No datasets built.")
+
+    # Console comparison: Binance vs Coinbase, calmest rolling window per weekday.
+    for tf in ("5m", "15m"):
+        bk, ck = f"binance_{tf}", f"coinbase_{tf}"
+        if bk in datasets and ck in datasets:
+            print(f"\n--- مقایسه Binance vs Coinbase ({tf}) — آرام‌ترین بازه‌ی هر روز ---")
+            for wd in A.WEEKDAY_DISPLAY_ORDER:
+                bl, ba = lowest_rolling(datasets[bk], wd)
+                cl, ca = lowest_rolling(datasets[ck], wd)
+                print(f"{A.PERSIAN_WEEKDAY[wd]:>9}: Binance {bl}={ba:.2f}  |  "
+                      f"Coinbase {cl}={ca:.2f}  (Δmiang={abs(ba - ca):.2f})")
+
+    data = {
+        "meta": {
+            "tz": tz_name,
+            "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+            "win_minutes": A.WIN_MINUTES,
+            "days": DAYS,
+        },
+        "order": A.WEEKDAY_DISPLAY_ORDER,
+        "names": {str(k): v for k, v in A.PERSIAN_WEEKDAY.items()},
+        "datasets": datasets,
+    }
+
     os.makedirs(OUT, exist_ok=True)
-    # Copy the PWA shell (index.html, app.js, manifest, sw.js, icons).
     shell = os.path.join(HERE, "pwa")
     for name in os.listdir(shell):
         shutil.copy(os.path.join(shell, name), os.path.join(OUT, name))
     with open(os.path.join(OUT, "data.json"), "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, separators=(",", ":"))
-
-    print(f"PWA built into {OUT}/ — {len(candles):,} candles, "
-          f"{sum(len(v) for v in rolling_out.values())} rolling windows.")
+    print(f"\nPWA built into {OUT}/ with datasets: {', '.join(datasets)}")
 
 
 if __name__ == "__main__":

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -49,6 +49,19 @@ function histBars(hist) {
 
 function render() {
   if (!DATA) return;
+  const key = $('exchange').value + '_' + $('tf').value;
+  const ds = DATA.datasets[key];
+  const out = $('out');
+  if (!ds) {
+    $('meta').textContent = 'برای این ترکیب صرافی/تایم‌فریم داده‌ای موجود نیست.';
+    out.innerHTML = '';
+    return;
+  }
+  const m = ds.meta;
+  $('meta').innerHTML =
+    `${m.exchange} • تایم‌فریم ${m.timeframe} • ` +
+    `${m.candles.toLocaleString('en')} کندل • ${m.oldest} تا ${m.newest} • ${DATA.meta.tz}`;
+
   const mode = $('window').value;
   const order = $('order').value;
   const wdSel = $('weekday').value;
@@ -58,11 +71,10 @@ function render() {
   const highest = order === 'highest';
 
   const days = wdSel === 'all' ? DATA.order : [parseInt(wdSel, 10)];
-  const out = $('out');
   out.innerHTML = '';
 
   for (const wd of days) {
-    let list = (DATA[mode][String(wd)] || []).slice();
+    let list = (ds[mode][String(wd)] || []).slice();
     if (!list.length) continue;
     list.sort((a, b) => (highest ? b.avg - a.avg : a.avg - b.avg)
       || (highest ? b.mx - a.mx : a.mx - b.mx) || a.start - b.start);
@@ -108,13 +120,9 @@ async function init() {
     $('meta').textContent = 'خطا در بارگذاری داده.';
     return;
   }
-  const m = DATA.meta;
-  $('meta').innerHTML =
-    `منبع: ${m.source} • ${m.candles.toLocaleString('en')} کندل • ` +
-    `${m.oldest} تا ${m.newest} • ${m.tz}`;
   fillWeekdays();
-  ['window', 'order', 'weekday', 'topn', 'nooverlap', 'hist'].forEach((id) =>
-    $(id).addEventListener('input', render));
+  ['exchange', 'tf', 'window', 'order', 'weekday', 'topn', 'nooverlap', 'hist']
+    .forEach((id) => $(id).addEventListener('input', render));
   render();
 }
 

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -53,9 +53,23 @@
 
   <div class="controls">
     <div class="ctrl">
+      <label>صرافی</label>
+      <select id="exchange">
+        <option value="binance">Binance</option>
+        <option value="coinbase">Coinbase</option>
+      </select>
+    </div>
+    <div class="ctrl">
+      <label>تایم‌فریم</label>
+      <select id="tf">
+        <option value="5m">۵ دقیقه</option>
+        <option value="15m">۱۵ دقیقه</option>
+      </select>
+    </div>
+    <div class="ctrl">
       <label>نوع بازه</label>
       <select id="window">
-        <option value="rolling">لغزان (هر ۵ دقیقه)</option>
+        <option value="rolling">لغزان</option>
         <option value="clock">راس‌ساعت</option>
       </select>
     </div>

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v2';
+const CACHE = 'btc-tanavob-v3';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
Adds parametrized Binance + Coinbase fetchers and infers the candle step so the rolling 60-minute window adapts to any timeframe. build_pwa now emits four datasets (Binance/Coinbase x 5m/15m) into data.json and logs a Binance-vs- Coinbase comparison. The PWA gains exchange and timeframe selectors.