### PR TITLE
Add 'gap to next alternation' analysis to the PWA

### DIFF
--- a/analyze_history.py
+++ b/analyze_history.py
@@ -620,6 +620,62 @@ def longest_alt_flips(directions):
 
 
 # ---------------------------------------------------------------------------
+# Whole-series alternation runs and the gap to the next run
+# ---------------------------------------------------------------------------
+def alternation_runs(candles):
+    """
+    Return a list of (start_flip, end_flip) flip-index spans for every maximal
+    strictly-alternating run across the whole candle series. A run of flips
+    i..j means candles i-1..j alternate; its length (in flips) is j-i+1.
+    """
+    dirs = [candle_direction(c) for c in candles]
+    n = len(dirs)
+    runs = []
+    i = 1
+    while i < n:
+        if dirs[i] != 0 and dirs[i - 1] != 0 and dirs[i] == -dirs[i - 1]:
+            j = i
+            while (j + 1 < n and dirs[j] != 0 and dirs[j + 1] != 0
+                   and dirs[j + 1] == -dirs[j]):
+                j += 1
+            runs.append((i, j))
+            i = j + 1
+        else:
+            i += 1
+    return runs
+
+
+def gaps_for_threshold(runs, threshold):
+    """
+    For every alternation run whose length (flips) >= threshold, the number of
+    non-alternating candles until the NEXT alternation run begins.
+    """
+    gaps = []
+    for k in range(len(runs) - 1):
+        s, e = runs[k]
+        if (e - s + 1) >= threshold:
+            gaps.append(runs[k + 1][0] - e - 1)
+    return gaps
+
+
+def gap_summary(gaps, cap=21):
+    """Compact stats for a list of candle-gaps (None if empty)."""
+    n = len(gaps)
+    if n == 0:
+        return None
+    s = sorted(gaps)
+    hist = Counter(min(g, cap) for g in gaps)  # `cap` means "cap or more"
+    return {
+        "n": n,
+        "avg": round(sum(gaps) / n, 2),
+        "med": s[n // 2],
+        "min": s[0],
+        "max": s[-1],
+        "hist": [[k, hist[k]] for k in sorted(hist)],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Build per (weekday, hour) samples and summarize
 # ---------------------------------------------------------------------------
 def build_hour_samples(candles, tz):

--- a/build_pwa.py
+++ b/build_pwa.py
@@ -85,15 +85,27 @@ def build_dataset(tz, source, interval, granularity, product, ex_label, tf_label
 
     oldest = datetime.fromtimestamp(candles[0]["time"], tz=tz)
     newest = datetime.fromtimestamp(candles[-1]["time"], tz=tz)
+
+    # Whole-series "gap to next alternation" stats, per threshold N.
+    runs = A.alternation_runs(candles)
+    max_len = max((e - s + 1 for s, e in runs), default=0)
+    gaps_out = {}
+    for N in range(1, min(max_len, 25) + 1):
+        summ = A.gap_summary(A.gaps_for_threshold(runs, N))
+        if summ:
+            gaps_out[str(N)] = summ
+
     return {
         "meta": {
             "exchange": ex_label, "timeframe": tf_label, "source": source,
             "interval": interval, "candles": len(candles),
             "oldest": oldest.strftime("%Y-%m-%d %H:%M"),
             "newest": newest.strftime("%Y-%m-%d %H:%M"),
+            "tf_minutes": granularity // 60,
         },
         "clock": clock_out,
         "rolling": rolling_out,
+        "gaps": gaps_out,
     }
 
 

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -112,6 +112,52 @@ function render() {
     });
     out.appendChild(card);
   }
+  renderGap();
+}
+
+function renderGap() {
+  if (!DATA) return;
+  const key = $('exchange').value + '_' + $('tf').value;
+  const ds = DATA.datasets[key];
+  const box = $('gapOut');
+  box.innerHTML = '';
+  if (!ds || !ds.gaps) { box.textContent = 'داده‌ای نیست.'; return; }
+  const N = Math.max(1, parseInt($('gapN').value || '6', 10));
+  const s = ds.gaps[String(N)];
+  if (!s) {
+    box.innerHTML = `<div class="gapbig">هیچ تناوبِ ≥ ${N} در کل سال رخ نداده.</div>`;
+    return;
+  }
+  const tfMin = ds.meta.tf_minutes || 5;
+  const big = document.createElement('div');
+  big.className = 'gapbig';
+  big.innerHTML =
+    `بعد از تناوبِ ≥ <b>${N}</b>، معمولاً <b>${s.avg}</b> کندل ` +
+    `(~${Math.round(s.avg * tfMin)} دقیقه) تا تناوب بعدی فاصله بوده.`;
+  box.appendChild(big);
+
+  const info = document.createElement('div');
+  info.innerHTML =
+    `<div class="row"><span>تعداد رخداد در سال</span><b>${s.n} بار</b></div>` +
+    `<div class="row"><span>میانه‌ی فاصله</span><b>${s.med} کندل</b></div>` +
+    `<div class="row"><span>کم‌ترین / بیش‌ترین فاصله</span><b>${s.min} / ${s.max} کندل</b></div>`;
+  box.appendChild(info);
+
+  // Distribution of gaps (last bucket = "21+").
+  const max = Math.max(...s.hist.map((p) => p[1]), 1);
+  const wrap = document.createElement('div');
+  wrap.className = 'hist';
+  for (const [g, c] of s.hist) {
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    const label = g >= 21 ? '۲۱+' : String(g);
+    bar.innerHTML =
+      `<span class="k">${label}</span>` +
+      `<span class="b" style="width:${Math.round((c / max) * 120) + 2}px"></span>` +
+      `<span class="c">${c}</span>`;
+    wrap.appendChild(bar);
+  }
+  box.appendChild(wrap);
 }
 
 function fillWeekdays() {
@@ -135,6 +181,7 @@ async function init() {
   fillWeekdays();
   ['exchange', 'tf', 'window', 'winlen', 'order', 'weekday', 'topn', 'nooverlap', 'hist']
     .forEach((id) => $(id).addEventListener('input', render));
+  $('gapN').addEventListener('input', renderGap);
   render();
 }
 

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -41,6 +41,13 @@
     .bar .k { width:14px; text-align:center; color:#666; }
     .bar .b { height:12px; background:#3a7bd5; border-radius:3px; min-width:2px; }
     .bar .c { color:#666; }
+    .gap { margin:4px 14px 8px; background:#fff; border:1px solid var(--line);
+           border-radius:12px; padding:12px 14px; }
+    .gap h2 { margin:0 0 6px; font-size:15px; color:var(--blue); }
+    .gaphelp { font-size:12px; color:#666; margin:0 0 10px; line-height:1.7; }
+    .gapctrl { max-width:220px; }
+    .gapbig { font-size:15px; margin:8px 0; }
+    .gapbig b { color:var(--blue); font-size:20px; }
     .hint { font-size:12px; color:#777; padding:0 14px 24px; line-height:1.8; }
     .star { color:#b8860b; }
   </style>
@@ -105,6 +112,17 @@
   </div>
 
   <main id="out"></main>
+
+  <section class="gap">
+    <h2>📏 فاصله تا تناوب بعدی</h2>
+    <p class="gaphelp">بعد از هر تناوبِ بزرگ‌تر-مساویِ آستانه، معمولاً چند کندل طول می‌کشد تا تناوبِ بعدی شروع شود؟ (روی همان صرافی و تایم‌فریم بالا)</p>
+    <div class="ctrl gapctrl">
+      <label>آستانه‌ی تناوب (≥)</label>
+      <input type="number" id="gapN" value="6" min="1" max="25">
+    </div>
+    <div id="gapOut"></div>
+  </section>
+
   <div class="hint">
     «تناوب» = طول بلندترین رشته‌ی یک‌درمیون شدن رنگ (سبز/قرمز) داخل هر بازه‌ی ۶۰ دقیقه‌ای،
     برحسب تعداد تغییر رنگ. مقدار ۰ یعنی بازه تک‌رنگ بوده. مرتب‌سازی بر اساس «میانگین» است.

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v7';
+const CACHE = 'btc-tanavob-v8';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
For a chosen threshold N, precompute over the whole year how many candles typically pass after each alternation run of length >= N until the next alternation begins (count, average, median, range, distribution). Exposed as a new section in the app with an adjustable N, per selected exchange/timeframe. Cache bumped to v8.