### PR TITLE
رفع تداخل Service Worker بین اپ بیت‌کوین و اپ ایمنی

### DIFF
--- a/hse_pwa/sw.js
+++ b/hse_pwa/sw.js
@@ -1,5 +1,5 @@
 // Service Worker — کش کامل برای کارکرد آفلاین
-const CACHE = "hse-pwa-v2";
+const CACHE = "hse-pwa-v3";
 const ASSETS = [
   "./",
   "./index.html",
@@ -26,16 +26,15 @@ self.addEventListener("activate", (e) => {
   );
 });
 
-// Cache-first: همه دارایی‌ها از کش خوانده می‌شوند تا آفلاین کار کند
+// Network-first: با هر رفرش آخرین نسخه از شبکه گرفته می‌شود تا آپدیت‌ها فوری
+// دیده شوند؛ در حالت آفلاین از کش استفاده می‌شود.
 self.addEventListener("fetch", (e) => {
   if (e.request.method !== "GET") return;
   e.respondWith(
-    caches.match(e.request).then((hit) =>
-      hit || fetch(e.request).then((res) => {
-        const copy = res.clone();
-        caches.open(CACHE).then((c) => c.put(e.request, copy)).catch(() => {});
-        return res;
-      }).catch(() => hit)
-    )
+    fetch(e.request).then((res) => {
+      const copy = res.clone();
+      caches.open(CACHE).then((c) => c.put(e.request, copy)).catch(() => {});
+      return res;
+    }).catch(() => caches.match(e.request))
   );
 });

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v9';
+const CACHE = 'btc-tanavob-v10';
 const ASSETS = [
   './',
   './index.html',
@@ -25,6 +25,9 @@ self.addEventListener('activate', (e) => {
 // immediately; fall back to cache only when offline.
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return;
+  // The HSE inspection app lives under /hse/ and manages its own service
+  // worker — do not intercept its requests so the two apps never collide.
+  if (new URL(e.request.url).pathname.includes('/hse/')) return;
   e.respondWith(
     fetch(e.request)
       .then((res) => {


### PR DESCRIPTION
رفع خرابی نمایش هم‌زمان دو اپ که روی یک سایت Pages میزبانی می‌شوند.

علت خرابی: Service Worker اپ بیت‌کوین (scope ریشه) درخواست‌های اپ ایمنی زیر `/hse/` را هم می‌گرفت و باعث تداخل می‌شد.

تغییرات:
- SW بیت‌کوین دیگر مسیرهای `/hse/` را مدیریت نمی‌کند (به اپ ایمنی واگذار می‌شود).
- SW اپ ایمنی به **network-first** تغییر کرد تا با هر رفرش آخرین نسخه بارگذاری شود.
- نسخه کش هر دو بالا رفت (btc v10، hse v3) تا دستگاه‌های نصب‌شده خودکار به‌روزرسانی شوند.

نتیجه: دو لینک دائمی جدا که هر دو پایدار کار می‌کنند و با رفرش آپدیت می‌شوند:
- بیت‌کوین: `…github.io/Tictactoestevie/`
- ایمنی: `…github.io/Tictactoestevie/hse/`

https://claude.ai/code/session_01MJTiQJzJS3imabukGxhFhm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJTiQJzJS3imabukGxhFhm)_