### PR TITLE
Fix empty window-length dropdown: use static options

### DIFF
--- a/pwa/app.js
+++ b/pwa/app.js
@@ -51,24 +51,15 @@ function winLabel(min) {
   return Number.isInteger(h) ? `${h.toLocaleString('fa')} ساعت` : `${min} دقیقه`;
 }
 
-// Rebuild the window-length dropdown from the lengths the dataset actually has.
+// The window-length options are static in the HTML; here we just disable the
+// ones this dataset doesn't have (e.g. 30m/1h on the 1-hour timeframe) and move
+// the selection to a valid one if needed.
 function syncWinlen(ds) {
   const sel = $('winlen');
-  const want = Object.keys(ds.rolling).map(Number).sort((a, b) => a - b);
-  const current = sel.value;
-  const have = Array.from(sel.options).map((o) => Number(o.value));
-  const same = have.length === want.length && have.every((v, i) => v === want[i]);
-  if (!same) {
-    sel.innerHTML = '';
-    for (const wm of want) {
-      const o = document.createElement('option');
-      o.value = String(wm);
-      o.textContent = winLabel(wm);
-      sel.appendChild(o);
-    }
-    // Keep the previous choice if still available, else prefer 60, else first.
-    sel.value = want.includes(Number(current)) ? current
-      : (want.includes(60) ? '60' : String(want[0]));
+  for (const o of sel.options) o.disabled = !(o.value in ds.rolling);
+  if (!(sel.value in ds.rolling)) {
+    const avail = Array.from(sel.options).find((o) => o.value in ds.rolling);
+    if (avail) sel.value = avail.value;
   }
 }
 

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -85,7 +85,17 @@
     </div>
     <div class="ctrl">
       <label>طول بازه</label>
-      <select id="winlen"></select>
+      <select id="winlen">
+        <option value="30">۳۰ دقیقه</option>
+        <option value="60" selected>۱ ساعت</option>
+        <option value="120">۲ ساعت</option>
+        <option value="180">۳ ساعت</option>
+        <option value="240">۴ ساعت</option>
+        <option value="300">۵ ساعت</option>
+        <option value="360">۶ ساعت</option>
+        <option value="480">۸ ساعت</option>
+        <option value="600">۱۰ ساعت</option>
+      </select>
     </div>
     <div class="ctrl">
       <label>مرتب‌سازی</label>

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v11';
+const CACHE = 'btc-tanavob-v12';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
The window-length <select> was populated dynamically by app.js, so a stale cached app.js (with the new empty-select index.html) left it blank. Make the options static in HTML and only disable lengths the dataset lacks, so the dropdown is never empty regardless of cache state. Cache bumped to v12.