### PR TITLE
Auto-refresh published data hourly via scheduled rebuild

### DIFF
--- a/.github/workflows/pwa.yml
+++ b/.github/workflows/pwa.yml
@@ -11,6 +11,10 @@ on:
       - "pwa/**"
       - "build_pwa.py"
       - ".github/workflows/pwa.yml"
+  schedule:
+    # Rebuild hourly so the published data stays fresh (UTC). GitHub may delay
+    # scheduled runs by a few minutes; that is fine for a yearly analysis.
+    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       source:


### PR DESCRIPTION
Add an hourly cron trigger to the PWA workflow so data.json is rebuilt with fresh candles automatically. Combined with the network-first service worker, a page refresh always shows data from the most recent (<=1h old) build.