### PR TITLE
Add per-window 'recent occurrences' drill-down

### DIFF
--- a/analyze_history.py
+++ b/analyze_history.py
@@ -717,7 +717,7 @@ def build_hour_samples(candles, tz):
     return samples
 
 
-def build_rolling_samples(candles, tz, win=None):
+def build_rolling_samples(candles, tz, win=None, with_times=False):
     """
     Returns: samples[weekday][(hour, minute)] = list of per-window flip counts.
 
@@ -726,6 +726,9 @@ def build_rolling_samples(candles, tz, win=None):
     weekday and clock time of its FIRST candle, so a window starting Sunday
     11:35 (and ending 12:35) lands in samples[Sun][(11, 35)]. Windows with a
     gap (missing candle) are skipped.
+
+    When with_times=True, each entry is a (start_unix, flips) tuple instead of
+    just flips (used to surface the most recent occurrences).
     """
     n = len(candles)
     times = [c["time"] for c in candles]
@@ -745,7 +748,9 @@ def build_rolling_samples(candles, tz, win=None):
         flips = longest_alt_flips(dirs[i : i + win])
         dt = datetime.fromtimestamp(times[i], tz=timezone.utc).astimezone(tz)
         key = (dt.hour, dt.minute)
-        samples[dt.weekday()].setdefault(key, []).append(flips)
+        samples[dt.weekday()].setdefault(key, []).append(
+            (times[i], flips) if with_times else flips
+        )
     return samples
 
 

--- a/build_pwa.py
+++ b/build_pwa.py
@@ -36,6 +36,7 @@ CONFIGS = [
 # built for a timeframe when it spans at least 2 candles (so 1h windows are
 # skipped on the 1-hour timeframe, 30m only applies to 5m/15m, etc.).
 WIN_LENGTHS = [30, 60, 120, 180, 240, 300, 360, 480, 600]
+RECENT_K = 6  # how many most-recent occurrences of each window to keep
 
 
 def pack(stats):
@@ -80,13 +81,17 @@ def build_dataset(tz, source, interval, granularity, product, ex_label, tf_label
         win = round(wm * 60 / granularity)  # candles per window
         if win < 2:
             continue  # window too short for this timeframe (e.g. 1h on 1h)
-        samples = A.build_rolling_samples(candles, tz, win=win)
+        samples = A.build_rolling_samples(candles, tz, win=win, with_times=True)
         per_wd = {}
         for wd in range(7):
             r = []
-            for (h, m), vals in samples[wd].items():
+            for (h, m), pairs in samples[wd].items():
+                flips = [f for _, f in pairs]
+                recent = pairs[-RECENT_K:]              # oldest -> newest
+                rc = [f for _, f in recent][::-1]        # newest first
+                rd = datetime.fromtimestamp(recent[-1][0], tz=tz).strftime("%Y-%m-%d")
                 r.append({"start": h * 60 + m, "label": A.window_label(h, m, wm),
-                          **pack(A.summarize_hour(vals))})
+                          **pack(A.summarize_hour(flips)), "rc": rc, "rd": rd})
             r.sort(key=lambda x: x["start"])
             per_wd[str(wd)] = r
         rolling_out[str(wm)] = per_wd

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -133,11 +133,55 @@ function render() {
         `<div class="row"><span>احتمال تناوب بالای میانگین</span><b>${w.ap}%</b></div>` +
         `<div class="row"><span>بیشینه</span><b>${w.mx} (${w.mxc} بار)</b></div>`;
       if (showHist) div.appendChild(histBars(w.hist));
+      if (w.rc && w.rc.length) div.appendChild(recentToggle(w, wd));
       card.appendChild(div);
     });
     out.appendChild(card);
   }
   renderGap();
+}
+
+// "YYYY-MM-DD" plus/minus a number of days.
+function addDays(s, delta) {
+  const [y, mo, da] = s.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, mo - 1, da));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  const p = (n) => String(n).padStart(2, '0');
+  return `${dt.getUTCFullYear()}-${p(dt.getUTCMonth() + 1)}-${p(dt.getUTCDate())}`;
+}
+
+// A collapsible "recent occurrences" panel for one window (last ~6 weeks).
+function recentToggle(w, wd) {
+  const dayName = DATA.names[String(wd)];
+  const btn = document.createElement('button');
+  btn.className = 'recentbtn';
+  btn.textContent = '🔎 رخدادهای اخیر این بازه';
+  const panel = document.createElement('div');
+  panel.className = 'recent';
+  panel.style.display = 'none';
+  btn.addEventListener('click', () => {
+    if (panel.dataset.built !== '1') {
+      const mx = Math.max(...w.rc);
+      const head = document.createElement('div');
+      head.className = 'rhead';
+      head.innerHTML =
+        `آخرین بار (${dayName} ${w.rd}): <b>${w.rc[0]}</b> تناوب` +
+        ` • بیشترین در ${w.rc.length} هفته‌ی اخیر: <b>${mx}</b>`;
+      panel.appendChild(head);
+      w.rc.forEach((v, i) => {
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.innerHTML = `<span>${dayName} ${addDays(w.rd, -7 * i)}</span><b>${v} تناوب</b>`;
+        panel.appendChild(row);
+      });
+      panel.dataset.built = '1';
+    }
+    panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+  });
+  const box = document.createElement('div');
+  box.appendChild(btn);
+  box.appendChild(panel);
+  return box;
 }
 
 function distBars(hist, unit) {

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -50,6 +50,13 @@
     .gapbig b { color:var(--blue); font-size:18px; }
     .gsub { font-weight:bold; color:var(--blue); margin:12px 0 4px; font-size:13px;
             border-top:1px solid #eef2f6; padding-top:8px; }
+    .recentbtn { margin-top:8px; width:100%; padding:8px; font-size:13px;
+                 background:#eef3f8; color:var(--blue); border:1px solid var(--line);
+                 border-radius:8px; font-weight:bold; }
+    .recent { margin-top:8px; padding:8px 10px; background:#f8fbff;
+              border:1px solid var(--line); border-radius:8px; }
+    .recent .rhead { font-size:13px; margin-bottom:6px; color:#333; line-height:1.8; }
+    .recent .rhead b { color:var(--blue); }
     .hint { font-size:12px; color:#777; padding:0 14px 24px; line-height:1.8; }
     .star { color:#b8860b; }
   </style>

--- a/pwa/sw.js
+++ b/pwa/sw.js
@@ -1,5 +1,5 @@
 // Simple offline-first service worker for the BTC alternation PWA.
-const CACHE = 'btc-tanavob-v12';
+const CACHE = 'btc-tanavob-v13';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
Each rolling window now carries its last 6 weekly occurrences (rc, newest first) plus the most-recent date (rd). The app shows a 'رخدادهای اخیر' button per window that reveals how many alternations the last few occurrences had — e.g. last Saturday 07:35-08:35. Cache bumped to v13.